### PR TITLE
Document Node.js >=24 requirement and add engines field; bump package version to 24.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+
+## Requirements
+
+- Node.js 24 or newer
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-portfolio",
-  "version": "0.0.0",
+  "version": "24.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-portfolio",
-      "version": "0.0.0",
+      "version": "24.0.0",
       "dependencies": {
         "@emailjs/browser": "^3.11.0",
         "@heroicons/react": "^2.0.18",
@@ -38,6 +38,9 @@
         "typescript": "^5.0.2",
         "vite": "^4.4.5",
         "vitest": "^0.34.4"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "my-portfolio",
   "private": true,
-  "version": "0.0.0",
+  "version": "24.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -41,5 +41,8 @@
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
     "vitest": "^0.34.4"
+  },
+  "engines": {
+    "node": ">=24"
   }
 }


### PR DESCRIPTION
### Motivation

- Make the project requirements explicit by documenting the minimum Node.js version.
- Ensure package metadata reflects the intended release/version and runtime constraint.
- Align the lockfile metadata with the package manifest to avoid confusion during installs.

### Description

- Added a "## Requirements" section to `README.md` stating "Node.js 24 or newer".
- Bumped `version` from `0.0.0` to `24.0.0` in `package.json` and `package-lock.json`.
- Added an `engines` entry with `"node": ">=24"` to both `package.json` and the root package entry in `package-lock.json`.
- Minor README spacing/formatting adjustments to accommodate the new section.

### Testing

- No automated tests were modified or executed as part of this change.
- CI should validate the change during the next run (install/lint/test) and will surface any engine compatibility issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6eb4ebd54832c933b4c29e247ba67)